### PR TITLE
fix: game_logic.update returned board when updating givens

### DIFF
--- a/src/sudoku/game_logic.py
+++ b/src/sudoku/game_logic.py
@@ -12,7 +12,7 @@ def update(game, move):
 
     if board[cell_index]["given"]:
         # Cannot modify pre-filled cells
-        return board
+        return game
 
     # Apply the player's move
     board[cell_index]["value"] = move[2] if move[2] != 0 else None


### PR DESCRIPTION
When user attempted to edit a 'given' value `gamelogic.update()` was returning `board` instead of the new higher-level `game` introduced in a previous commit.

- Changed return value from `board` to `game` 